### PR TITLE
Refactoring Postgres connection & models

### DIFF
--- a/db/storage/postgres/__init__.py
+++ b/db/storage/postgres/__init__.py
@@ -1,0 +1,2 @@
+from .connection import * # noqa
+from .mixins import * # noqa

--- a/db/storage/postgres/connection.py
+++ b/db/storage/postgres/connection.py
@@ -1,15 +1,16 @@
 """
 Database connection
 """
+import re
 from urllib.parse import quote
 
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import declared_attr
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.ext.declarative import declarative_base
 
 from libs.environs import env
-
 
 DB_USER = env.str('DB_USER')
 DB_NAME = env.str('DB_NAME')
@@ -17,10 +18,7 @@ DB_HOST = env.str('DB_HOST')
 DB_PORT = env.int('DB_PORT')
 DB_PASSWORD = quote(env.str('DB_PASSWORD'))
 
-
-db_url = f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}" # noqa
-
-Base = declarative_base()
+db_url = f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"  # noqa
 
 engine = create_async_engine(
     url=db_url,
@@ -34,6 +32,25 @@ async_session = sessionmaker(
     class_=AsyncSession,
     expire_on_commit=False,
 )
+
+
+class Base(DeclarativeBase):
+    @declared_attr.directive
+    @classmethod
+    def __tablename__(cls) -> str:
+        """
+        Converts `CamelCase` class name
+        to `snake_case` table name, adding 's'.
+
+        :return: Pluralized snake_case table name.
+        """
+        name = re.sub(
+            r"(?<!^)(?=[A-Z])",
+            "_",
+            cls.__name__,
+        ).lower()
+        pluralized_name = name + "s"
+        return pluralized_name
 
 
 async def get_db() -> AsyncSession:

--- a/db/storage/postgres/mixins.py
+++ b/db/storage/postgres/mixins.py
@@ -1,0 +1,15 @@
+"""
+Database models mixins
+"""
+from sqlalchemy.orm import (
+    Mapped,
+    mapped_column,
+)
+
+
+class IntIdPkMixin:
+    """
+    Mixin is a primary key of type int.
+    """
+
+    id: Mapped[int] = mapped_column(primary_key=True)

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,18 +1,15 @@
 """
 User table
 """
-from sqlalchemy import Column
-from sqlalchemy import String
-from sqlalchemy import Integer
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
 
 from db.storage.postgres import Base
+from db.storage.postgres import IntIdPkMixin
 
 
-class User(Base):
-    __tablename__ = "users"
-
-    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
-    name = Column(String, index=True)
+class User(Base, IntIdPkMixin):
+    name: Mapped[str] = mapped_column(index=True)
 
     def __repr__(self):
         return f"<Item id={self.id} name={self.name}>"


### PR DESCRIPTION
## Refactor Base Model and Update User for SQLAlchemy 2.x

This PR updates the SQLAlchemy setup:

*   Refactored the base model definition for Postgres connections to use a class with automatic table name generation.
*   Added a base mixin (`IntIdPkMixin`) for integer primary keys.
*   Updated the `User` model to be compatible with SQLAlchemy 2.x syntax.